### PR TITLE
Better Anti-Lib-Patch mechanism

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,6 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
     defaultConfig {
         applicationId "id.kuro.androidnativeguard"
         minSdk 24
-        targetSdk 33
+        targetSdk 35
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.AndroidNativeGuard"
-        android:extractNativeLibs="true"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -6,17 +6,29 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-register")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden")
+if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    # Set visibility to hidden by default
+    set(BUILD_CXX_AND_C_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden \
+    -fno-rtti -fno-exceptions")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-rtti -fno-exceptions")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_RELEASE} ${BUILD_CXX_AND_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} ${BUILD_CXX_AND_C_FLAGS}")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdata-sections -ffunction-sections")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdata-sections -ffunction-sections")
+else ()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g -DDEBUG")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g -DDEBUG")
+
+    add_compile_definitions(DEBUG_BUILD)
+endif ()
 
 if (${ANDROID_ABI} STREQUAL "armeabi-v7a")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -marm")
 endif ()
+
+# Add root directory reference for easier header includes,
+# It also let you avoid relative path e.g. #include "../include/header.h"
+include_directories(./)
 
 add_library(NativeGuard SHARED
         main.cpp

--- a/app/src/main/cpp/Modules/AntiDebug/AntiDebug.cpp
+++ b/app/src/main/cpp/Modules/AntiDebug/AntiDebug.cpp
@@ -69,7 +69,7 @@ bool AntiDebug::scanTaskStatuses() {
                 }
 
                 char statusPath[512];
-                sprintf(statusPath, AY_OBFUSCATE("/proc/self/task/%s/status").operator char *(), dirp->d_name);
+                sprintf(statusPath, AY_OBFUSCATE("/proc/self/task/%s/status"), dirp->d_name);
                 int statusFd = SecureAPI::openat(AT_FDCWD, statusPath, O_RDONLY, 0);
                 LOGI("AntiDebug::scanTaskStatuses statusPath: %s | statusFd: %d", statusPath, statusFd);
                 if (statusFd == -1) {

--- a/app/src/main/cpp/Modules/AntiDump/AntiDump.cpp
+++ b/app/src/main/cpp/Modules/AntiDump/AntiDump.cpp
@@ -38,8 +38,8 @@ AntiDump::AntiDump(void (*callback)()) : onDumpDetected(callback) {
             }
             if (dirp->d_type == DT_DIR) {
                 char memPath[512], pagemapPath[512];
-                sprintf(memPath, AY_OBFUSCATE("/proc/self/task/%s/mem").operator char *(), dirp->d_name);
-                sprintf(pagemapPath, AY_OBFUSCATE("/proc/self/task/%s/pagemap").operator char *(), dirp->d_name);
+                sprintf(memPath, AY_OBFUSCATE("/proc/self/task/%s/mem"), dirp->d_name);
+                sprintf(pagemapPath, AY_OBFUSCATE("/proc/self/task/%s/pagemap"), dirp->d_name);
 
                 this->m_wd[this->m_count++] = SecureAPI::inotify_add_watch(this->m_fd, memPath, IN_ACCESS | IN_OPEN);
                 this->m_wd[this->m_count++] = SecureAPI::inotify_add_watch(this->m_fd, pagemapPath, IN_ACCESS | IN_OPEN);

--- a/app/src/main/cpp/Modules/AntiLibPatch/AntiLibPatch.cpp
+++ b/app/src/main/cpp/Modules/AntiLibPatch/AntiLibPatch.cpp
@@ -24,8 +24,8 @@
 
 static std::vector<std::string> blacklists {
     // Add your library here incase you don't want a certain library to be detected when it's tampered
-    AY_OBFUSCATE("libclang_rt.ubsan_standalone-aarch64-android.so").operator char *(),
-    AY_OBFUSCATE("libart.so").operator char *()
+    AY_OBFUSCATE("libclang_rt.ubsan_standalone-aarch64-android.so"),
+    AY_OBFUSCATE("libart.so")
 };
 
 __attribute__((always_inline)) static inline uint32_t crc32(uint8_t *data, size_t size) {

--- a/app/src/main/cpp/Modules/AntiLibPatch/AntiLibPatch.h
+++ b/app/src/main/cpp/Modules/AntiLibPatch/AntiLibPatch.h
@@ -1,15 +1,33 @@
 #include "../IModule.h"
+#include "constants.h"
+
+struct ExecutableRegion {
+    std::string                 libPath;
+    Pointer                     baseAddress;
+    std::pair<Pointer, Pointer> chunkData;
+    uint32_t                    initialChecksum;
+
+    ExecutableRegion(std::string path,
+                     Pointer address,
+                     std::pair<Pointer, Pointer> chunk,
+                     uint32_t initialChecksum)
+            : libPath(std::move(path)),
+              baseAddress(address),
+              chunkData(std::move(chunk)),
+              initialChecksum(initialChecksum) {}
+};
 
 class AntiLibPatch : public IModule {
-private:
-    std::map<std::string, std::map<std::string, uint32_t>> m_checksums;
+    using onLibTamperedCallbackType = void (*)(const char *libPath,
+                                               uint32_t old_checksum,
+                                               uint32_t new_checksum);
+    onLibTamperedCallbackType onLibTampered;
 public:
-    AntiLibPatch(void (*)(const char *, const char *, uint32_t, uint32_t) = 0);
+    explicit AntiLibPatch(onLibTamperedCallbackType = nullptr);
     const char *getName() override;
     eSeverity getSeverity() override;
 
     bool execute() override;
 private:
-    std::map<std::string, std::map<std::string, uint32_t>> m_last_checksums;
-    void (*onLibTampered)(const char *name, const char *section, uint32_t old_checksum, uint32_t new_checksum);
+    std::vector<ExecutableRegion> regions{};
 };

--- a/app/src/main/cpp/Modules/FridaDetect/FridaDetect.cpp
+++ b/app/src/main/cpp/Modules/FridaDetect/FridaDetect.cpp
@@ -81,7 +81,7 @@ bool FridaDetect::detectFridaPipe() {
                 }
 
                 char linkPath[512];
-                sprintf(linkPath, AY_OBFUSCATE("/proc/self/fd/%s").operator char *(), dirp->d_name);
+                sprintf(linkPath, AY_OBFUSCATE("/proc/self/fd/%s"), dirp->d_name);
                 char linkTarget[512];
                 int linkTargetLen = SecureAPI::readlinkat(fd, dirp->d_name, linkTarget, sizeof(linkTarget));
                 if (linkTargetLen == -1) {
@@ -130,7 +130,7 @@ bool FridaDetect::detectFridaListener() {
         }
 
         char req[1024];
-        sprintf(req, AY_OBFUSCATE("GET /ws HTTP/1.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: CpxD2C5REVLHvsUC9YAoqg==\r\nSec-WebSocket-Version: 13\r\nHost: %s:%d\r\nUser-Agent: Frida/16.1.7\r\n\r\n").operator char *(), inet_ntoa(addr.sin_addr), ntohs(addr.sin_port));
+        sprintf(req, AY_OBFUSCATE("GET /ws HTTP/1.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: CpxD2C5REVLHvsUC9YAoqg==\r\nSec-WebSocket-Version: 13\r\nHost: %s:%d\r\nUser-Agent: Frida/16.1.7\r\n\r\n"), inet_ntoa(addr.sin_addr), ntohs(addr.sin_port));
         SecureAPI::write(fd, req, SecureAPI::strlen(req));
 
         char res[1024];

--- a/app/src/main/cpp/Modules/RiGisk/RiGisk.cpp
+++ b/app/src/main/cpp/Modules/RiGisk/RiGisk.cpp
@@ -56,17 +56,17 @@ eSeverity RiGisk::getSeverity() {
 bool RiGisk::execute() {
     LOGI("RiGisk::execute");
 
-    SandHook::ElfImg linker(AY_OBFUSCATE("/linker").operator char *());
-    solist = getStaticPointer<soinfo>(linker, AY_OBFUSCATE("__dl__ZL6solist").operator char *());
-    somain = getStaticPointer<soinfo>(linker, AY_OBFUSCATE("__dl__ZL6somain").operator char *());
-    preloads = reinterpret_cast<std::vector<soinfo *> *>(linker.getSymbAddress(AY_OBFUSCATE("__dl__ZL13g_ld_preloads").operator char *()));
+    SandHook::ElfImg linker(AY_OBFUSCATE("/linker"));
+    solist = getStaticPointer<soinfo>(linker, AY_OBFUSCATE("__dl__ZL6solist"));
+    somain = getStaticPointer<soinfo>(linker, AY_OBFUSCATE("__dl__ZL6somain"));
+    preloads = reinterpret_cast<std::vector<soinfo *> *>(linker.getSymbAddress(AY_OBFUSCATE("__dl__ZL13g_ld_preloads")));
     LOGI("RiGisk::execute solist: %p, somain: %p, preloads: %p", solist, somain, preloads);
 
-    soinfo::get_realpath_sym = reinterpret_cast<decltype(soinfo::get_realpath_sym)>(linker.getSymbAddress(AY_OBFUSCATE("__dl__ZNK6soinfo12get_realpathEv").operator char *()));
-    soinfo::get_soname_sym = reinterpret_cast<decltype(soinfo::get_soname_sym)>(linker.getSymbAddress(AY_OBFUSCATE("__dl__ZNK6soinfo10get_sonameEv").operator char *()));
+    soinfo::get_realpath_sym = reinterpret_cast<decltype(soinfo::get_realpath_sym)>(linker.getSymbAddress(AY_OBFUSCATE("__dl__ZNK6soinfo12get_realpathEv")));
+    soinfo::get_soname_sym = reinterpret_cast<decltype(soinfo::get_soname_sym)>(linker.getSymbAddress(AY_OBFUSCATE("__dl__ZNK6soinfo10get_sonameEv")));
     LOGI("RiGisk::execute get_realpath_sym: %p, get_soname_sym: %p", soinfo::get_realpath_sym, soinfo::get_soname_sym);
 
-    auto vsdo = getStaticPointer<soinfo>(linker, AY_OBFUSCATE("__dl__ZL4vdso").operator char *());
+    auto vsdo = getStaticPointer<soinfo>(linker, AY_OBFUSCATE("__dl__ZL4vdso"));
     LOGI("RiGisk::execute vsdo: %p", vsdo);
     for (size_t i = 0; i < 1024 / sizeof(void *); i++) {
         auto *possible_next = *(void **) ((uintptr_t) solist + i * sizeof(void *));

--- a/app/src/main/cpp/Utils/Log.h
+++ b/app/src/main/cpp/Utils/Log.h
@@ -1,7 +1,11 @@
-#include <stdio.h>
+#include <cstdio>
 #include <unistd.h>
 
 #include <android/log.h>
 #include <string>
 
-#define LOGI(...) //((void)__android_log_print(ANDROID_LOG_INFO, "NativeGuard", __VA_ARGS__)) // Disable this on production
+#ifdef DEBUG_BUILD
+#define LOGI(...) ((void)__android_log_print(ANDROID_LOG_INFO, "NativeGuard", __VA_ARGS__)) // Disable this on production
+#else
+#define LOGI(...)
+#endif

--- a/app/src/main/cpp/Utils/obfuscate.h
+++ b/app/src/main/cpp/Utils/obfuscate.h
@@ -29,12 +29,14 @@ std::cout << obfuscated_string << std::endl;
 
 #pragma once
 
+#include <string>
+
 // Workaround for __LINE__ not being constexpr when /ZI (Edit and Continue) is enabled in Visual Studio
 // See: https://developercommunity.visualstudio.com/t/-line-cannot-be-used-as-an-argument-for-constexpr/195665
 #ifdef _MSC_VER
 #define AY_CAT(X,Y) AY_CAT2(X,Y)
-	#define AY_CAT2(X,Y) X##Y
-	#define AY_LINE int(AY_CAT(__LINE__,U))
+#define AY_CAT2(X,Y) X##Y
+#define AY_LINE int(AY_CAT(__LINE__,U))
 #else
 #define AY_LINE __LINE__
 #endif
@@ -46,175 +48,158 @@ std::cout << obfuscated_string << std::endl;
 #define AY_OBFUSCATE_DEFAULT_KEY ay::generate_key(AY_LINE)
 #endif
 
-namespace ay
-{
+namespace ay {
     using size_type = unsigned long long;
     using key_type = unsigned long long;
 
-    template <typename T>
+    template<typename T>
     struct remove_const_ref {
         using type = T;
     };
 
-    template <typename T>
-    struct remove_const_ref<T&> {
+    template<typename T>
+    struct remove_const_ref<T &> {
         using type = T;
     };
 
-    template <typename T>
+    template<typename T>
     struct remove_const_ref<const T> {
         using type = T;
     };
 
-    template <typename T>
-    struct remove_const_ref<const T&> {
+    template<typename T>
+    struct remove_const_ref<const T &> {
         using type = T;
     };
 
-    template <typename T>
+    template<typename T>
     using char_type = typename remove_const_ref<T>::type;
 
     // Generate a pseudo-random key that spans all 8 bytes
-    constexpr key_type generate_key(key_type seed)
-{
-    // Use the MurmurHash3 64-bit finalizer to hash our seed
-    key_type key = seed;
-    key ^= (key >> 33);
-    key *= 0xff51afd7ed558ccd;
-    key ^= (key >> 33);
-    key *= 0xc4ceb9fe1a85ec53;
-    key ^= (key >> 33);
+    constexpr key_type generate_key(key_type seed) {
+        // Use the MurmurHash3 64-bit finalizer to hash our seed
+        key_type key = seed;
+        key ^= (key >> 33);
+        key *= 0xff51afd7ed558ccd;
+        key ^= (key >> 33);
+        key *= 0xc4ceb9fe1a85ec53;
+        key ^= (key >> 33);
 
-    // Make sure that a bit in each byte is set
-    key |= 0x0101010101010101ull;
+        // Make sure that a bit in each byte is set
+        key |= 0x0101010101010101ull;
 
-    return key;
-}
+        return key;
+    }
 
 // Obfuscates or deobfuscates data with key
-template <typename CHAR_TYPE>
-constexpr void cipher(CHAR_TYPE* data, size_type size, key_type key)
-{
-    // Obfuscate with a simple XOR cipher based on key
-    for (size_type i = 0; i < size; i++)
-    {
-        data[i] ^= CHAR_TYPE((key >> ((i % 8) * 8)) & 0xFF);
+    template<typename CHAR_TYPE>
+    constexpr void cipher(CHAR_TYPE *data, size_type size, key_type key) {
+        // Obfuscate with a simple XOR cipher based on key
+        for (size_type i = 0; i < size; i++) {
+            data[i] ^= CHAR_TYPE((key >> ((i % 8) * 8)) & 0xFF);
+        }
     }
-}
 
 // Obfuscates a string at compile time
-template <size_type N, key_type KEY, typename CHAR_TYPE = char>
-class obfuscator
-{
-public:
-    // Obfuscates the string 'data' on construction
-    constexpr obfuscator(const CHAR_TYPE* data)
-    {
-        // Copy data
-        for (size_type i = 0; i < N; i++)
-        {
-            m_data[i] = data[i];
+    template<size_type N, key_type KEY, typename CHAR_TYPE = char>
+    class obfuscator {
+    public:
+        // Obfuscates the string 'data' on construction
+        constexpr explicit obfuscator(const CHAR_TYPE *data) {
+            // Copy data
+            for (size_type i = 0; i < N; i++) {
+                m_data[i] = data[i];
+            }
+
+            // On construction each of the characters in the string is
+            // obfuscated with an XOR cipher based on key
+            cipher(m_data, N, KEY);
         }
 
-        // On construction each of the characters in the string is
-        // obfuscated with an XOR cipher based on key
-        cipher(m_data, N, KEY);
-    }
+        constexpr const CHAR_TYPE *data() const {
+            return &m_data[0];
+        }
 
-    constexpr const CHAR_TYPE* data() const
-    {
-        return &m_data[0];
-    }
+        [[nodiscard]] constexpr size_type size() const {
+            return N;
+        }
 
-    constexpr size_type size() const
-    {
-        return N;
-    }
+        [[nodiscard]] constexpr key_type key() const {
+            return KEY;
+        }
 
-    constexpr key_type key() const
-    {
-        return KEY;
-    }
+    private:
 
-private:
-
-    CHAR_TYPE m_data[N]{};
-};
+        CHAR_TYPE m_data[N]{};
+    };
 
 // Handles decryption and re-encryption of an encrypted string at runtime
-template <size_type N, key_type KEY, typename CHAR_TYPE = char>
-class obfuscated_data
-{
-public:
-    obfuscated_data(const obfuscator<N, KEY, CHAR_TYPE>& obfuscator)
-    {
-        // Copy obfuscated data
-        for (size_type i = 0; i < N; i++)
-        {
-            m_data[i] = obfuscator.data()[i];
+    template<size_type N, key_type KEY, typename CHAR_TYPE = char>
+    class obfuscated_data {
+    public:
+        explicit obfuscated_data(const obfuscator<N, KEY, CHAR_TYPE> &obfuscator) {
+            // Copy obfuscated data
+            for (size_type i = 0; i < N; i++) {
+                m_data[i] = obfuscator.data()[i];
+            }
         }
-    }
 
-    ~obfuscated_data()
-    {
-        // Zero m_data to remove it from memory
-        for (size_type i = 0; i < N; i++)
-        {
-            m_data[i] = 0;
+        ~obfuscated_data() {
+            // Zero m_data to remove it from memory
+            for (size_type i = 0; i < N; i++) {
+                m_data[i] = 0;
+            }
         }
-    }
 
-    // Returns a pointer to the plain text string, decrypting it if
-    // necessary
-    operator CHAR_TYPE* ()
-    {
-        decrypt();
-        return m_data;
-    }
-
-    // Manually decrypt the string
-    void decrypt()
-    {
-        if (m_encrypted)
-        {
-            cipher(m_data, N, KEY);
-            m_encrypted = false;
+        operator std::string() {
+            decrypt();
+            return m_data;
         }
-    }
 
-    // Manually re-encrypt the string
-    void encrypt()
-    {
-        if (!m_encrypted)
-        {
-            cipher(m_data, N, KEY);
-            m_encrypted = true;
+        // Returns a pointer to the plain text string, decrypting it if
+        // necessary
+        operator CHAR_TYPE *() {
+            decrypt();
+            return m_data;
         }
-    }
 
-    // Returns true if this string is currently encrypted, false otherwise.
-    bool is_encrypted() const
-    {
-        return m_encrypted;
-    }
+        // Manually decrypt the string
+        void decrypt() {
+            if (m_encrypted) {
+                cipher(m_data, N, KEY);
+                m_encrypted = false;
+            }
+        }
 
-private:
+        // Manually re-encrypt the string
+        void encrypt() {
+            if (!m_encrypted) {
+                cipher(m_data, N, KEY);
+                m_encrypted = true;
+            }
+        }
 
-    // Local storage for the string. Call is_encrypted() to check whether or
-    // not the string is currently obfuscated.
-    CHAR_TYPE m_data[N];
+        // Returns true if this string is currently encrypted, false otherwise.
+        [[nodiscard]] bool is_encrypted() const {
+            return m_encrypted;
+        }
 
-    // Whether data is currently encrypted
-    bool m_encrypted{ true };
-};
+    private:
+
+        // Local storage for the string. Call is_encrypted() to check whether or
+        // not the string is currently obfuscated.
+        CHAR_TYPE m_data[N];
+
+        // Whether data is currently encrypted
+        bool m_encrypted{true};
+    };
 
 // This function exists purely to extract the number of elements 'N' in the
 // array 'data'
-template <size_type N, key_type KEY = AY_OBFUSCATE_DEFAULT_KEY, typename CHAR_TYPE = char>
-constexpr auto make_obfuscator(const CHAR_TYPE(&data)[N])
-{
-    return obfuscator<N, KEY, CHAR_TYPE>(data);
-}
+    template<size_type N, key_type KEY = AY_OBFUSCATE_DEFAULT_KEY, typename CHAR_TYPE = char>
+    constexpr auto make_obfuscator(const CHAR_TYPE(&data)[N]) {
+        return obfuscator<N, KEY, CHAR_TYPE>(data);
+    }
 }
 
 // Obfuscates the string 'data' at compile-time and returns a reference to a
@@ -227,15 +212,15 @@ constexpr auto make_obfuscator(const CHAR_TYPE(&data)[N])
 // functions for decrypting the string and is also implicitly convertable to a
 // char*
 #define AY_OBFUSCATE_KEY(data, key) \
-	[]() -> ay::obfuscated_data<sizeof(data)/sizeof(data[0]), key, ay::char_type<decltype(*data)>>& { \
-		static_assert(sizeof(decltype(key)) == sizeof(ay::key_type), "key must be a 64 bit unsigned integer"); \
-		static_assert((key) >= (1ull << 56), "key must span all 8 bytes"); \
-		using char_type = ay::char_type<decltype(*data)>; \
-		constexpr auto n = sizeof(data)/sizeof(data[0]); \
-		constexpr auto obfuscator = ay::make_obfuscator<n, key, char_type>(data); \
-		thread_local auto obfuscated_data = ay::obfuscated_data<n, key, char_type>(obfuscator); \
-		return obfuscated_data; \
-	}()
+    []() -> ay::obfuscated_data<sizeof(data)/sizeof((data)[0]), key, ay::char_type<decltype(*(data))>>& { \
+        static_assert(sizeof(decltype(key)) == sizeof(ay::key_type), "key must be a 64 bit unsigned integer"); \
+        static_assert((key) >= (1ull << 56), "key must span all 8 bytes"); \
+        using char_type = ay::char_type<decltype(*(data))>; \
+        constexpr auto n = sizeof(data)/sizeof((data)[0]); \
+        constexpr auto obfuscator = ay::make_obfuscator<n, key, char_type>(data); \
+        thread_local auto obfuscated_data = ay::obfuscated_data<n, key, char_type>(obfuscator); \
+        return obfuscated_data; \
+    }()
 
 /* -------------------------------- LICENSE ------------------------------------
 

--- a/app/src/main/cpp/Utils/obfuscate.h
+++ b/app/src/main/cpp/Utils/obfuscate.h
@@ -156,6 +156,11 @@ namespace ay {
             return m_data;
         }
 
+        operator std::string_view() {
+            decrypt();
+            return m_data;
+        }
+
         // Returns a pointer to the plain text string, decrypting it if
         // necessary
         operator CHAR_TYPE *() {

--- a/app/src/main/cpp/constants.h
+++ b/app/src/main/cpp/constants.h
@@ -1,0 +1,20 @@
+//
+// Created by Msii on 11/21/2024.
+//
+
+#ifndef ANDROID_NATIVE_GUARD_CONSTANTS_H
+#define ANDROID_NATIVE_GUARD_CONSTANTS_H
+
+#define _forceinline __attribute__((always_inline)) inline
+
+#ifdef __LP64__
+#define x32_64(_32, _64) _64
+#else
+#define x32_64(_32, _64) _32
+#endif
+
+using Pointer = unsigned long;
+
+constexpr Pointer null = 0UL;
+
+#endif //ANDROID_NATIVE_GUARD_CONSTANTS_H

--- a/app/src/main/java/id/kuro/androidnativeguard/MainActivity.java
+++ b/app/src/main/java/id/kuro/androidnativeguard/MainActivity.java
@@ -2,6 +2,7 @@ package id.kuro.androidnativeguard;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.os.Bundle;
 import android.os.Handler;
@@ -9,6 +10,7 @@ import android.text.Html;
 import android.widget.TextView;
 
 public class MainActivity extends AppCompatActivity {
+    @SuppressLint("StaticFieldLeak")
     static TextView tv_main;
 
     @Override

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed May 03 23:08:16 SGT 2023
+#Thu Nov 21 18:49:51 IST 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
Hello,

I have added implicit assignment operator to std::string, which i think should make life easier.
and there will be no need to explicitly use `.operator char *()` when assigning an obfucated string to std::string

e.g.
`std::string hello = AY_OBFUSCATE("Hello from C++")`
instead of
`std::string hello = AY_OBFUSCATE("Hello from C++").operator char *()`

Edit:

I pushed another commit which in my opinion should be better than the previous AntiLibPatch approach,
The reason behind so is when you use android:extractNativeLibs="true", your libraries will be stored on device as a standalone file, not within APK file, this could be a security hole, since a reverse engineers/cracker can replace your .so with patched one with root privileges.

so using my approach will let you avoid .so replacement, also it will still check for modifications since initial checksum will backup up as soon as library is loaded.

Let me know if further elaboration is needed, I'm happy to answer your questions